### PR TITLE
Log progress with logger.info not logger.error

### DIFF
--- a/src/tensorpack_cpu/tensorpack/train/multigpu.py
+++ b/src/tensorpack_cpu/tensorpack/train/multigpu.py
@@ -320,7 +320,7 @@ class AsyncMultiGPUTrainer(MultiGPUTrainer):
              step_time=round(elapsed_time, 2),
              mean_step_time=round(mean_step_time,2),
              it_s=round(1000.0 / mean_step_time, 2)))
-        logger.error(s)
+        logger.info(s)
         self.main_thread_timer = start_timer()
 
     def _trigger_epoch(self):


### PR DESCRIPTION
With logger.error it's very confusing as the log lines appear like that:

[0130 13:09:45 @multigpu.py:323] ERR [p0962]  step: count(1), step_time 36832.49, mean_step_time 36832.49, it/s 0.03
[0130 13:09:45 @multigpu.py:323] ERR [p0964]  step: count(1), step_time 36830.08, mean_step_time 36830.08, it/s 0.03
[0130 13:09:45 @multigpu.py:323] ERR [p0967]  step: count(1), step_time 36853.41, mean_step_time 36853.41, it/s 0.03

where ERR is red. So one thinks that there are some errors, where
in fact we are just logging some stats and everything is fine.