### PR TITLE
Remove red herring stack trace printing

### DIFF
--- a/src/OpenAIGym/train.py
+++ b/src/OpenAIGym/train.py
@@ -272,12 +272,6 @@ class Model(ModelDesc):
                 return policy, value
 
     def _build_graph(self, inputs):
-        # import ipdb; ipdb.set_trace()
-        eprint('===== [{}] PRINTING BUILD GRAPH STACK AT {}=============='.format(socket.gethostname(),
-                                                                                  time.time()))
-        traceback.print_stack(file=sys.stderr)
-
-
         with tf.device('/cpu:0'):
             with tf.variable_scope(tf.get_variable_scope(), reuse=None):
                 state, action, futurereward, global_step_from_predict, init_R, isOver = inputs


### PR DESCRIPTION
It looks like a leftover after debugging.

It's better if stack traces in the log are real exceptions not red herrings like that:

```
File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/OpenAIGym//train.py", line 727, in <module>
    trainer.train()
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/train/multigpu.py", line 230, in train
    callbacks.setup_graph(self) # TODO use weakref instead?
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/callbacks/base.py", line 40, in setup_graph
    self._setup_graph()
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/callbacks/group.py", line 66, in _setup_graph
    cb.setup_graph(self.trainer)
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/callbacks/base.py", line 40, in setup_graph
    self._setup_graph()
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/OpenAIGym//train.py", line 366, in _setup_graph
    self.trainer.get_predict_funcs(['state'], ['logitsT', 'pred_value'], self.predictor_threads),
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/train/trainer.py", line 331, in get_predict_funcs
    return [self.get_predict_func(input_names, output_names, k) for k in range(n)]
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/train/trainer.py", line 328, in get_predict_func
    return self.predictor_factory.get_predictor(input_names, output_names, tower)
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/train/trainer.py", line 54, in get_predictor
    self._build_predict_tower()
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/train/trainer.py", line 71, in _build_predict_tower
    self.model, self.towers)
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/predict/base.py", line 134, in build_multi_tower_prediction_graph
    model.build_graph(input_vars)
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/tensorpack_cpu/tensorpack/models/model_desc.py", line 140, in build_graph
    self._build_graph(model_inputs)
  File "/net/archive/groups/plggluna/adam/Distributed-BA3C/src/OpenAIGym//train.py", line 278, in _build_graph
    traceback.print_stack(file=sys.stderr)
```